### PR TITLE
Recurso: Suporte a Todos Parâmetros de Boletos da PagHiper

### DIFF
--- a/src/DTO/Objects/Billet/Basic.php
+++ b/src/DTO/Objects/Billet/Basic.php
@@ -15,6 +15,17 @@ class Basic implements Arrayable
         private ?int $days_due_date = 2,
         private ?string $type_bank_slip = 'boletoA4',
         private ?int $discount_cents = 0,
+        private ?int $shipping_price_cents = null,
+        private ?string $shipping_methods = null,
+        private ?string $partners_id = null,
+        private ?int $number_ntfiscal = null,
+        private ?bool $fixed_description = null,
+        private ?string $seller_description = null,
+        private ?int $late_payment_fine = null,
+        private ?bool $per_day_interest = null,
+        private ?int $early_payment_discounts_days = null,
+        private ?int $early_payment_discounts_cents = null,
+        private ?int $open_after_day_due = null,
     ) {
         //
     }
@@ -22,11 +33,22 @@ class Basic implements Arrayable
     public function toArray(): array
     {
         return [
-            'order_id'         => $this->order_id,
-            'notification_url' => $this->notification_url,
-            'days_due_date'    => $this->days_due_date,
-            'type_bank_slip'   => $this->type_bank_slip,
-            'discount_cents'   => $this->discount_cents,
+            'order_id'                      => $this->order_id,
+            'notification_url'              => $this->notification_url,
+            'days_due_date'                 => $this->days_due_date,
+            'type_bank_slip'                => $this->type_bank_slip,
+            'discount_cents'                => $this->discount_cents,
+            'shipping_price_cents'          => $this->shipping_price_cents,
+            'shipping_methods'              => $this->shipping_methods,
+            'partners_id'                   => $this->partners_id,
+            'number_ntfiscal'               => $this->number_ntfiscal,
+            'fixed_description'             => $this->fixed_description,
+            'seller_description'            => $this->seller_description,
+            'late_payment_fine'             => $this->late_payment_fine,
+            'per_day_interest'              => $this->per_day_interest,
+            'early_payment_discounts_days'  => $this->early_payment_discounts_days,
+            'early_payment_discounts_cents' => $this->early_payment_discounts_cents,
+            'open_after_day_due'            => $this->open_after_day_due,
         ];
     }
 }

--- a/tests/Dto/BasicTest.php
+++ b/tests/Dto/BasicTest.php
@@ -13,11 +13,22 @@ it('should return valid basic instance using make with array', function () {
         ->toArray())
         ->toBeArray()
         ->toBe([
-            'order_id'         => '12345678901',
-            'notification_url' => $url,
-            'days_due_date'    => 10,
-            'type_bank_slip'   => 'foo-bar',
-            'discount_cents'   => 20000,
+            'order_id'                      => '12345678901',
+            'notification_url'              => $url,
+            'days_due_date'                 => 10,
+            'type_bank_slip'                => 'foo-bar',
+            'discount_cents'                => 20000,
+            'shipping_price_cents'          => null,
+            'shipping_methods'              => null,
+            'partners_id'                   => null,
+            'number_ntfiscal'               => null,
+            'fixed_description'             => null,
+            'seller_description'            => null,
+            'late_payment_fine'             => null,
+            'per_day_interest'              => null,
+            'early_payment_discounts_days'  => null,
+            'early_payment_discounts_cents' => null,
+            'open_after_day_due'            => null,
         ]);
 });
 
@@ -25,11 +36,22 @@ it('should return valid basic instance using make with deconstruction', function
     $payer = Basic::make('12345678901', $url = fake()->url(), 5, 'foo-bar', 1500);
 
     expect($payer->toArray())->toBeArray()->toBe([
-        'order_id'         => '12345678901',
-        'notification_url' => $url,
-        'days_due_date'    => 5,
-        'type_bank_slip'   => 'foo-bar',
-        'discount_cents'   => 1500,
+        'order_id'                      => '12345678901',
+        'notification_url'              => $url,
+        'days_due_date'                 => 5,
+        'type_bank_slip'                => 'foo-bar',
+        'discount_cents'                => 1500,
+        'shipping_price_cents'          => null,
+        'shipping_methods'              => null,
+        'partners_id'                   => null,
+        'number_ntfiscal'               => null,
+        'fixed_description'             => null,
+        'seller_description'            => null,
+        'late_payment_fine'             => null,
+        'per_day_interest'              => null,
+        'early_payment_discounts_days'  => null,
+        'early_payment_discounts_cents' => null,
+        'open_after_day_due'            => null,
     ]);
 });
 
@@ -39,13 +61,27 @@ it('should be able to construct basic object using make and set', function () {
         ->set('notification_url', $url = fake()->url())
         ->set('days_due_date', 55)
         ->set('type_bank_slip', 'foo-bar-baz')
-        ->set('discount_cents', 2700);
+        ->set('discount_cents', 2700)
+        ->set('shipping_price_cents', 123)
+        ->set('shipping_methods', 'foo-bar')
+        ->set('open_after_day_due', 144);
 
     expect($basic->toArray())->toBeArray()->toBe([
-        'order_id'         => '12345678901',
-        'notification_url' => $url,
-        'days_due_date'    => 55,
-        'type_bank_slip'   => 'foo-bar-baz',
-        'discount_cents'   => 2700,
+        'order_id'                      => '12345678901',
+        'notification_url'              => $url,
+        'days_due_date'                 => 55,
+        'type_bank_slip'                => 'foo-bar-baz',
+        'discount_cents'                => 2700,
+        'shipping_price_cents'          => 123,
+        'shipping_methods'              => 'foo-bar',
+        'partners_id'                   => null,
+        'number_ntfiscal'               => null,
+        'fixed_description'             => null,
+        'seller_description'            => null,
+        'late_payment_fine'             => null,
+        'per_day_interest'              => null,
+        'early_payment_discounts_days'  => null,
+        'early_payment_discounts_cents' => null,
+        'open_after_day_due'            => 144,
     ]);
 });


### PR DESCRIPTION
## O que
Suporte a todos os [parâmetros de boleto bancário da PagHiper](https://dev.paghiper.com/reference/especificacoes-dos-campos-que-devem-ser-enviados-na-requisicao-boleto)

## Por que
Viabilizar formato de uso de acordo com o que o lojista desejar.