### PR TITLE
Correção de Bug com Comando de Instalação

### DIFF
--- a/README.md
+++ b/README.md
@@ -553,8 +553,6 @@ Route::post('/payment/notification', function (Request $request) {
 ## Pendências
 
 - Integração com [PIX do PagHiper](https://dev.paghiper.com/reference/emissao-de-pix-paghiper)
-- Integração com [Contas Bancárias](https://dev.paghiper.com/reference/solicitacao-saque)
-- Integração com [Listas de Transações](https://dev.paghiper.com/reference/listar-transacoes-via-api-exemplo)
 
 <a name="contributing"></a>
 ## Contribuição
@@ -586,7 +584,7 @@ cd <pasta> && composer install
 4. Execute testes:
 
 ```bash
-composer test # ou composer test:parallel
+composer test
 ```
 
 5. Analise a integridade do código: 

--- a/src/Console/InstallPagHiperCommand.php
+++ b/src/Console/InstallPagHiperCommand.php
@@ -13,7 +13,7 @@ class InstallPagHiperCommand extends Command
     public function handle(): int
     {
         $this->callSilent('vendor:publish', [
-            '--tag'   => 'paghiper-config',
+            '--tag'   => 'paghiper',
             '--force' => $this->option('force'),
         ]);
 

--- a/tests/Commands/InstallPagHiperCommandTest.php
+++ b/tests/Commands/InstallPagHiperCommandTest.php
@@ -1,0 +1,6 @@
+<?php
+
+it('should be able to install paghiper successfully', function () {
+    $this->artisan('paghiper:install')
+        ->assertSuccessful();
+});


### PR DESCRIPTION
<!-- 
O PR está sujeito a ser negado se:
- O PR contiver mudanças irrelevantes, inúteis ou desnecessárias
- O código não for escrito em inglês
- O código não seguir a PSR12
- O código não ter sido formatado usando Laravel Pint
- O código não possuir testes ou os testes falharem
-->

## O que
Correção aplicada ao comando de instalação

## Por que
Sem isso o comando `php artisan paghiper:install` não funcionará corretamente